### PR TITLE
Status Badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,19 @@
 ## Description
 
+[![CI](https://concourse.ns8-infrastructure.com/api/v1/teams/main/pipelines/protect-php-sdk/jobs/test/badge)](https://concourse.ns8-infrastructure.com/teams/main/pipelines/protect-php-sdk/jobs/test)
+[![CI](https://concourse.ns8-infrastructure.com/api/v1/teams/main/pipelines/protect-php-sdk/jobs/test/badge?title=tests)](https://concourse.ns8-infrastructure.com/teams/main/pipelines/protect-php-sdk/jobs/test)
+
+<!--
+
+TODO: Uncomment when php sdk published to public packagist:
+
+[![Latest Stable Version](https://poser.pugx.org/ns8/protect-php-sdk/version)](https://packagist.org/packages/ns8/protect-php-sdk)
+[![Latest Stable Version](https://poser.pugx.org/ns8/protect-php-sdk/license)](https://packagist.org/packages/ns8/protect-php-sdk)
+-->
+
 This is the PHP SDK for NS8 Protect.
 
 ## Getting Started
 
 Please [read the docs](https://github.com/ns8inc/protect-php-sdk/tree/master/public/en/platform/protect-php-sdk).
+


### PR DESCRIPTION
Summary: 
Adds test and build status badges that link to concourse.  
Add commented-out badge links for packagist version and repo license that should start to work once the repo exists publicly in packagist.