### PR TITLE
Updating links in docs for `protect-sdk-php`. ch-19029

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,18 @@
 ## Description
 
-[![CI](https://concourse.ns8-infrastructure.com/api/v1/teams/main/pipelines/protect-php-sdk/jobs/test/badge)](https://concourse.ns8-infrastructure.com/teams/main/pipelines/protect-php-sdk/jobs/test)
-[![CI](https://concourse.ns8-infrastructure.com/api/v1/teams/main/pipelines/protect-php-sdk/jobs/test/badge?title=tests)](https://concourse.ns8-infrastructure.com/teams/main/pipelines/protect-php-sdk/jobs/test)
+[![CI](https://concourse.ns8-infrastructure.com/api/v1/teams/main/pipelines/protect-sdk-php/jobs/test/badge)](https://concourse.ns8-infrastructure.com/teams/main/pipelines/protect-sdk-php/jobs/test)
+[![CI](https://concourse.ns8-infrastructure.com/api/v1/teams/main/pipelines/protect-sdk-php/jobs/test/badge?title=tests)](https://concourse.ns8-infrastructure.com/teams/main/pipelines/protect-sdk-php/jobs/test)
 
 <!--
 
 TODO: Uncomment when php sdk published to public packagist:
 
-[![Latest Stable Version](https://poser.pugx.org/ns8/protect-php-sdk/version)](https://packagist.org/packages/ns8/protect-php-sdk)
-[![Latest Stable Version](https://poser.pugx.org/ns8/protect-php-sdk/license)](https://packagist.org/packages/ns8/protect-php-sdk)
+[![Latest Stable Version](https://poser.pugx.org/ns8/protect-sdk-php/version)](https://packagist.org/packages/ns8/protect-sdk-php)
+[![Latest Stable Version](https://poser.pugx.org/ns8/protect-sdk-php/license)](https://packagist.org/packages/ns8/protect-sdk-php)
 -->
 
 This is the PHP SDK for NS8 Protect.
 
 ## Getting Started
 
-Please [read the docs](https://github.com/ns8inc/protect-php-sdk/tree/master/public/en/platform/protect-php-sdk).
-
+Please [read the docs](https://github.com/ns8inc/protect-sdk-php/tree/master/public/en/platform/protect-sdk-php).

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -6,7 +6,7 @@ image_resource:
   source: { repository: php, tag: cli }
 
 inputs:
-  - name: protect-php-sdk
+  - name: protect-sdk-php
 
 run:
   path: /bin/sh
@@ -35,7 +35,7 @@ run:
         exit 1
       fi
 
-      cd protect-php-sdk
+      cd protect-sdk-php
       composer install -q
 
       if [ $? -ne 0 ]; then

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use AspectMock\Kernel;
 
 Kernel::getInstance()->init([
-    'cacheDir' => '/tmp/protect-php-sdk',
+    'cacheDir' => '/tmp/protect-sdk-php',
     'debug' => true,
     'includePaths' => [
         dirname(__DIR__) . '/src',


### PR DESCRIPTION
See also:

* https://github.com/ns8inc/protect-integration-magento/pull/257
* https://github.com/ns8inc/protect-tools-js/pull/10
* https://github.com/ns8inc/protect-sdk-js/pull/82
* https://github.com/ns8inc/generator-protect-integration/pull/4
* https://github.com/ns8inc/protect-integration-sap/pull/3
* https://github.com/ns8inc/protect-sdk-php/pull/41
* https://github.com/ns8inc/protect-integration-sap/pull/3
* https://github.com/ns8inc/protect-sdk-switchboard/pull/8
* https://github.com/ns8inc/protect-integration-docs/pull/13