### PR TITLE
If Protect responds with an error instead of the TrueStats script, don't cache it.

### DIFF
--- a/src/Analytics/Client.php
+++ b/src/Analytics/Client.php
@@ -67,8 +67,9 @@ class Client extends BaseClient
 
         $script        = self::getHttpClient()->sendNonObjectRequest(self::getTrueStatsRoute());
         $decodedScript = json_decode($script) ?? '';
+        $error         = json_decode($decodedScript, true);
 
-        if ($decodedScript !== '') {
+        if ($decodedScript !== '' && ! isset($error['error'])) {
             self::saveScriptToCache($decodedScript);
         }
 

--- a/tests/Analytics/ClientTest.php
+++ b/tests/Analytics/ClientTest.php
@@ -253,7 +253,7 @@ class ClientTest extends TestCase
     }
 
     /**
-     * Test value return for fetching the True Stats script (cached)
+     * Assert that the script doesn't get cached in case of a Protect error
      *
      * @return void
      *


### PR DESCRIPTION
This should fix (or at least, work around) the issue that @crodr177 reported [here](https://app.clubhouse.io/ns8/story/28965/implement-script-caching-for-truestats-script#activity-30210).

Sadly, the build seems to be failing due to CircleCI apparently deleting yet another one of our deploy keys. 🤦 