### PR TITLE
Fix tag versioning.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
           name: Install gren
       - run:
           command: |
-            version=$(git tag -l | sort -V | tail -n 1 | awk -F . '{$NF+=1; print $0}' OFS=".")
+            version=$(git tag -l | sort -V | tail -n 1)
             echo "export VERSION=$version" >> $BASH_ENV
           name: Get Version
       - run:


### PR DESCRIPTION
# Story Reference

[ch35507](https://app.clubhouse.io/ns8/story/35507/auto-create-github-releases-on-every-deploy)

## Summary

This fixes an issue with obtaining the correct version before publishing a GH release.

## Author Checklist

I have added/updated:

- [ ] Tests
- [ ] Documentation
- [ ] Release notes (title of this PR)

## Version Bump

- [X] Patch (bug fix - backwards compatible)
- [ ] Minor (new functionality - backwards compatible)
- [ ] Major (significant change - not backwards compatible)
