### PR TITLE
Cache each store's TrueStats script in a separate file.

### DIFF
--- a/src/Analytics/Client.php
+++ b/src/Analytics/Client.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NS8\ProtectSDK\Analytics;
 
+use NS8\ProtectSDK\Config\Manager as ConfigManager;
 use NS8\ProtectSDK\Http\Client as HttpClient;
 use function file_exists;
 use function file_get_contents;
@@ -27,8 +28,10 @@ class Client extends BaseClient
 
     /**
      * The temporary file used for caching the TrueStats script.
+     *
+     * "%u" gets replaced with the individual store ID.
      */
-    protected const TRUE_STATS_CACHE_FILE = 'ns8-truestats.json';
+    protected const TRUE_STATS_CACHE_FILE = 'ns8-truestats-%u.js';
 
     /**
      * The TrueStats script gets cached for 1 day
@@ -107,7 +110,9 @@ class Client extends BaseClient
      */
     protected static function getFullPathToScriptCacheFile() : string
     {
-        return sprintf('%s/%s', sys_get_temp_dir(), self::TRUE_STATS_CACHE_FILE);
+        $cacheFile = sprintf(self::TRUE_STATS_CACHE_FILE, ConfigManager::getValue('store_id') ?? 1);
+
+        return sprintf('%s/%s', sys_get_temp_dir(), $cacheFile);
     }
 
     /**

--- a/src/Config/ManagerStructure.php
+++ b/src/Config/ManagerStructure.php
@@ -151,6 +151,7 @@ abstract class ManagerStructure
         self::$configData                     = array_replace_recursive(self::$configData, $baseData, $customData);
         self::$configData['platform_version'] = $platformVersion;
         self::$configData['php_version']      = $phpVersion ?? phpversion();
+        self::$configData['store_id']         = 1; // This is the default, use setValue() to override.
         self::$environment                    = $environment ?? self::$configData['default_environment'];
         self::validateConfigEnvRequirements();
         self::validateInitialConfigData();

--- a/src/Logging/Client.php
+++ b/src/Logging/Client.php
@@ -103,7 +103,7 @@ class Client extends ClientBase
      * Constructor to initialize logging client
      *
      * @param ?Logger        $logger        Logging object to be used by the client
-     * @param ?ConfigManager $configManager Config manager usrd to fetch settings
+     * @param ?ConfigManager $configManager Config manager used to fetch settings
      */
     public function __construct(?Logger $logger = null, ?ConfigManager $configManager = null)
     {


### PR DESCRIPTION
# Story Reference

[ch37012](https://app.clubhouse.io/ns8/story/37012/retrieve-shop-access-token-prior-to-registration)

## Summary

Cache each store's TrueStats script in a separate file.

## Author Checklist

I have added/updated:

- [X] Tests
- [ ] Documentation
- [X] Release notes (title of this PR)

## Version Bump

- [X] Patch (bug fix - backwards compatible)
- [ ] Minor (new functionality - backwards compatible)
- [ ] Major (significant change - not backwards compatible)
