### PR TITLE
Resolve Laminas library issues with Magento by switching back to Zend (for now).

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
     "name": "ns8/protect-sdk",
     "require": {
         "php": "^7.1.3",
-        "monolog/monolog": "^1.0",
-        "laminas/laminas-http": "^2.12",
-        "laminas/laminas-json": "^2"
+        "zendframework/zend-http": ">=2.8.2",
+        "zendframework/zend-json": ">=2.6.1",
+        "monolog/monolog": "^1.0"
     },
     "type": "library",
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "27f951ee98d4709eb360cc041c210f7a",
+    "content-hash": "30befc8c6d7f4f9120df93cc1d8de9bf",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -39,476 +39,17 @@
             "time": "2017-02-14T19:40:03+00:00"
         },
         {
-            "name": "laminas/laminas-escaper",
-            "version": "2.6.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-escaper.git",
-                "reference": "25f2a053eadfa92ddacb609dcbbc39362610da70"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-escaper/zipball/25f2a053eadfa92ddacb609dcbbc39362610da70",
-                "reference": "25f2a053eadfa92ddacb609dcbbc39362610da70",
-                "shasum": ""
-            },
-            "require": {
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^5.6 || ^7.0"
-            },
-            "replace": {
-                "zendframework/zend-escaper": "self.version"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "~1.0.0",
-                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.6.x-dev",
-                    "dev-develop": "2.7.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Escaper\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Securely and safely escape HTML, HTML attributes, JavaScript, CSS, and URLs",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "escaper",
-                "laminas"
-            ],
-            "time": "2019-12-31T16:43:30+00:00"
-        },
-        {
-            "name": "laminas/laminas-http",
-            "version": "2.12.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-http.git",
-                "reference": "48bd06ffa3a6875e2b77d6852405eb7b1589d575"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-http/zipball/48bd06ffa3a6875e2b77d6852405eb7b1589d575",
-                "reference": "48bd06ffa3a6875e2b77d6852405eb7b1589d575",
-                "shasum": ""
-            },
-            "require": {
-                "laminas/laminas-loader": "^2.5.1",
-                "laminas/laminas-stdlib": "^3.2.1",
-                "laminas/laminas-uri": "^2.5.2",
-                "laminas/laminas-validator": "^2.10.1",
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^5.6 || ^7.0"
-            },
-            "replace": {
-                "zendframework/zend-http": "^2.11.2"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "~1.0.0",
-                "laminas/laminas-config": "^3.1 || ^2.6",
-                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.3"
-            },
-            "suggest": {
-                "paragonie/certainty": "For automated management of cacert.pem"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.12.x-dev",
-                    "dev-develop": "2.13.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Http\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Provides an easy interface for performing Hyper-Text Transfer Protocol (HTTP) requests",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "http",
-                "http client",
-                "laminas"
-            ],
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2020-06-23T15:14:37+00:00"
-        },
-        {
-            "name": "laminas/laminas-json",
-            "version": "2.6.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-json.git",
-                "reference": "db58425b7f0eba44a7539450cc926af80915951a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-json/zipball/db58425b7f0eba44a7539450cc926af80915951a",
-                "reference": "db58425b7f0eba44a7539450cc926af80915951a",
-                "shasum": ""
-            },
-            "require": {
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^5.5 || ^7.0"
-            },
-            "replace": {
-                "zendframework/zend-json": "self.version"
-            },
-            "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
-                "laminas/laminas-http": "^2.5.4",
-                "laminas/laminas-server": "^2.6.1",
-                "laminas/laminas-stdlib": "^2.5 || ^3.0",
-                "laminas/laminas-xml": "^1.0.2",
-                "phpunit/phpunit": "~4.0"
-            },
-            "suggest": {
-                "laminas/laminas-http": "Laminas\\Http component, required to use Laminas\\Json\\Server",
-                "laminas/laminas-server": "Laminas\\Server component, required to use Laminas\\Json\\Server",
-                "laminas/laminas-stdlib": "Laminas\\Stdlib component, for use with caching Laminas\\Json\\Server responses",
-                "laminas/laminas-xml": "To support Laminas\\Json\\Json::fromXml() usage"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.6-dev",
-                    "dev-develop": "2.7-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Json\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "provides convenience methods for serializing native PHP to JSON and decoding JSON to native PHP",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "json",
-                "laminas"
-            ],
-            "time": "2019-12-31T17:15:00+00:00"
-        },
-        {
-            "name": "laminas/laminas-loader",
-            "version": "2.6.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-loader.git",
-                "reference": "5d01c2c237ae9e68bec262f339947e2ea18979bc"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-loader/zipball/5d01c2c237ae9e68bec262f339947e2ea18979bc",
-                "reference": "5d01c2c237ae9e68bec262f339947e2ea18979bc",
-                "shasum": ""
-            },
-            "require": {
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^5.6 || ^7.0"
-            },
-            "replace": {
-                "zendframework/zend-loader": "self.version"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "~1.0.0",
-                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.4"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.6.x-dev",
-                    "dev-develop": "2.7.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Loader\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Autoloading and plugin loading strategies",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "laminas",
-                "loader"
-            ],
-            "time": "2019-12-31T17:18:27+00:00"
-        },
-        {
-            "name": "laminas/laminas-stdlib",
-            "version": "3.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "2b18347625a2f06a1a485acfbc870f699dbe51c6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/2b18347625a2f06a1a485acfbc870f699dbe51c6",
-                "reference": "2b18347625a2f06a1a485acfbc870f699dbe51c6",
-                "shasum": ""
-            },
-            "require": {
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^5.6 || ^7.0"
-            },
-            "replace": {
-                "zendframework/zend-stdlib": "self.version"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "~1.0.0",
-                "phpbench/phpbench": "^0.13",
-                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.2.x-dev",
-                    "dev-develop": "3.3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Stdlib\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "SPL extensions, array utilities, error handlers, and more",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "laminas",
-                "stdlib"
-            ],
-            "time": "2019-12-31T17:51:15+00:00"
-        },
-        {
-            "name": "laminas/laminas-uri",
-            "version": "2.7.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-uri.git",
-                "reference": "6be8ce19622f359b048ce4faebf1aa1bca73a7ff"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-uri/zipball/6be8ce19622f359b048ce4faebf1aa1bca73a7ff",
-                "reference": "6be8ce19622f359b048ce4faebf1aa1bca73a7ff",
-                "shasum": ""
-            },
-            "require": {
-                "laminas/laminas-escaper": "^2.5",
-                "laminas/laminas-validator": "^2.10",
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^5.6 || ^7.0"
-            },
-            "replace": {
-                "zendframework/zend-uri": "self.version"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "~1.0.0",
-                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.4"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.7.x-dev",
-                    "dev-develop": "2.8.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Uri\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "A component that aids in manipulating and validating » Uniform Resource Identifiers (URIs)",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "laminas",
-                "uri"
-            ],
-            "time": "2019-12-31T17:56:00+00:00"
-        },
-        {
-            "name": "laminas/laminas-validator",
-            "version": "2.13.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "93593684e70b8ed1e870cacd34ca32b0c0ace185"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/93593684e70b8ed1e870cacd34ca32b0c0ace185",
-                "reference": "93593684e70b8ed1e870cacd34ca32b0c0ace185",
-                "shasum": ""
-            },
-            "require": {
-                "container-interop/container-interop": "^1.1",
-                "laminas/laminas-stdlib": "^3.2.1",
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^7.1"
-            },
-            "replace": {
-                "zendframework/zend-validator": "^2.13.0"
-            },
-            "require-dev": {
-                "laminas/laminas-cache": "^2.6.1",
-                "laminas/laminas-coding-standard": "~1.0.0",
-                "laminas/laminas-config": "^2.6",
-                "laminas/laminas-db": "^2.7",
-                "laminas/laminas-filter": "^2.6",
-                "laminas/laminas-http": "^2.5.4",
-                "laminas/laminas-i18n": "^2.6",
-                "laminas/laminas-math": "^2.6",
-                "laminas/laminas-servicemanager": "^2.7.5 || ^3.0.3",
-                "laminas/laminas-session": "^2.8",
-                "laminas/laminas-uri": "^2.5",
-                "phpunit/phpunit": "^7.5.20 || ^8.5.2",
-                "psr/http-client": "^1.0",
-                "psr/http-factory": "^1.0",
-                "psr/http-message": "^1.0"
-            },
-            "suggest": {
-                "laminas/laminas-db": "Laminas\\Db component, required by the (No)RecordExists validator",
-                "laminas/laminas-filter": "Laminas\\Filter component, required by the Digits validator",
-                "laminas/laminas-i18n": "Laminas\\I18n component to allow translation of validation error messages",
-                "laminas/laminas-i18n-resources": "Translations of validator messages",
-                "laminas/laminas-math": "Laminas\\Math component, required by the Csrf validator",
-                "laminas/laminas-servicemanager": "Laminas\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",
-                "laminas/laminas-session": "Laminas\\Session component, ^2.8; required by the Csrf validator",
-                "laminas/laminas-uri": "Laminas\\Uri component, required by the Uri and Sitemap\\Loc validators",
-                "psr/http-message": "psr/http-message, required when validating PSR-7 UploadedFileInterface instances via the Upload and UploadFile validators"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.13.x-dev",
-                    "dev-develop": "2.14.x-dev"
-                },
-                "laminas": {
-                    "component": "Laminas\\Validator",
-                    "config-provider": "Laminas\\Validator\\ConfigProvider"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Validator\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Validation classes for a wide range of domains, and the ability to chain validators to create complex validation criteria",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "laminas",
-                "validator"
-            ],
-            "time": "2020-03-31T18:57:01+00:00"
-        },
-        {
-            "name": "laminas/laminas-zendframework-bridge",
-            "version": "1.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
-                "reference": "fcd87520e4943d968557803919523772475e8ea3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/fcd87520e4943d968557803919523772475e8ea3",
-                "reference": "fcd87520e4943d968557803919523772475e8ea3",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.6 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.1",
-                "squizlabs/php_codesniffer": "^3.5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev",
-                    "dev-develop": "1.1.x-dev"
-                },
-                "laminas": {
-                    "module": "Laminas\\ZendFrameworkBridge"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/autoload.php"
-                ],
-                "psr-4": {
-                    "Laminas\\ZendFrameworkBridge\\": "src//"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Alias legacy ZF class names to Laminas Project equivalents.",
-            "keywords": [
-                "ZendFramework",
-                "autoloading",
-                "laminas",
-                "zf"
-            ],
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2020-05-20T16:45:56+00:00"
-        },
-        {
             "name": "monolog/monolog",
-            "version": "1.25.5",
+            "version": "1.25.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "1817faadd1846cd08be9a49e905dc68823bc38c0"
+                "reference": "3022efff205e2448b560c833c6fbbf91c3139168"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/1817faadd1846cd08be9a49e905dc68823bc38c0",
-                "reference": "1817faadd1846cd08be9a49e905dc68823bc38c0",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/3022efff205e2448b560c833c6fbbf91c3139168",
+                "reference": "3022efff205e2448b560c833c6fbbf91c3139168",
                 "shasum": ""
             },
             "require": {
@@ -582,7 +123,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-23T08:35:51+00:00"
+            "time": "2020-05-22T07:31:27+00:00"
         },
         {
             "name": "psr/container",
@@ -679,6 +220,375 @@
                 "psr-3"
             ],
             "time": "2020-03-23T09:12:05+00:00"
+        },
+        {
+            "name": "zendframework/zend-escaper",
+            "version": "2.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-escaper.git",
+                "reference": "3801caa21b0ca6aca57fa1c42b08d35c395ebd5f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-escaper/zipball/3801caa21b0ca6aca57fa1c42b08d35c395ebd5f",
+                "reference": "3801caa21b0ca6aca57fa1c42b08d35c395ebd5f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2",
+                "zendframework/zend-coding-standard": "~1.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6.x-dev",
+                    "dev-develop": "2.7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Escaper\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Securely and safely escape HTML, HTML attributes, JavaScript, CSS, and URLs",
+            "keywords": [
+                "ZendFramework",
+                "escaper",
+                "zf"
+            ],
+            "abandoned": "laminas/laminas-escaper",
+            "time": "2019-09-05T20:03:20+00:00"
+        },
+        {
+            "name": "zendframework/zend-http",
+            "version": "2.11.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-http.git",
+                "reference": "e15e0ce45a2a4f642cd0b7b4f4d4d0366b729a1a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-http/zipball/e15e0ce45a2a4f642cd0b7b4f4d4d0366b729a1a",
+                "reference": "e15e0ce45a2a4f642cd0b7b4f4d4d0366b729a1a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0",
+                "zendframework/zend-loader": "^2.5.1",
+                "zendframework/zend-stdlib": "^3.2.1",
+                "zendframework/zend-uri": "^2.5.2",
+                "zendframework/zend-validator": "^2.10.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.3",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-config": "^3.1 || ^2.6"
+            },
+            "suggest": {
+                "paragonie/certainty": "For automated management of cacert.pem"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.11.x-dev",
+                    "dev-develop": "2.12.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Http\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Provides an easy interface for performing Hyper-Text Transfer Protocol (HTTP) requests",
+            "keywords": [
+                "ZendFramework",
+                "http",
+                "http client",
+                "zend",
+                "zf"
+            ],
+            "abandoned": "laminas/laminas-http",
+            "time": "2019-12-30T20:47:33+00:00"
+        },
+        {
+            "name": "zendframework/zend-json",
+            "version": "3.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-json.git",
+                "reference": "e9ddb1192d93fe7fff846ac895249c39db75132b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-json/zipball/e9ddb1192d93fe7fff846ac895249c39db75132b",
+                "reference": "e9ddb1192d93fe7fff846ac895249c39db75132b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7.23 || ^6.4.3",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-stdlib": "^2.7.7 || ^3.1"
+            },
+            "suggest": {
+                "zendframework/zend-json-server": "For implementing JSON-RPC servers",
+                "zendframework/zend-xml2json": "For converting XML documents to JSON"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1.x-dev",
+                    "dev-develop": "3.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Json\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides convenience methods for serializing native PHP to JSON and decoding JSON to native PHP",
+            "keywords": [
+                "ZendFramework",
+                "json",
+                "zf"
+            ],
+            "abandoned": "laminas/laminas-json",
+            "time": "2019-10-09T13:56:13+00:00"
+        },
+        {
+            "name": "zendframework/zend-loader",
+            "version": "2.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-loader.git",
+                "reference": "91da574d29b58547385b2298c020b257310898c6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-loader/zipball/91da574d29b58547385b2298c020b257310898c6",
+                "reference": "91da574d29b58547385b2298c020b257310898c6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.4",
+                "zendframework/zend-coding-standard": "~1.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6.x-dev",
+                    "dev-develop": "2.7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Loader\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Autoloading and plugin loading strategies",
+            "keywords": [
+                "ZendFramework",
+                "loader",
+                "zf"
+            ],
+            "abandoned": "laminas/laminas-loader",
+            "time": "2019-09-04T19:38:14+00:00"
+        },
+        {
+            "name": "zendframework/zend-stdlib",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-stdlib.git",
+                "reference": "66536006722aff9e62d1b331025089b7ec71c065"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-stdlib/zipball/66536006722aff9e62d1b331025089b7ec71c065",
+                "reference": "66536006722aff9e62d1b331025089b7ec71c065",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpbench/phpbench": "^0.13",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2",
+                "zendframework/zend-coding-standard": "~1.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2.x-dev",
+                    "dev-develop": "3.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Stdlib\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "SPL extensions, array utilities, error handlers, and more",
+            "keywords": [
+                "ZendFramework",
+                "stdlib",
+                "zf"
+            ],
+            "abandoned": "laminas/laminas-stdlib",
+            "time": "2018-08-28T21:34:05+00:00"
+        },
+        {
+            "name": "zendframework/zend-uri",
+            "version": "2.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-uri.git",
+                "reference": "bfc4a5b9a309711e968d7c72afae4ac50c650083"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-uri/zipball/bfc4a5b9a309711e968d7c72afae4ac50c650083",
+                "reference": "bfc4a5b9a309711e968d7c72afae4ac50c650083",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0",
+                "zendframework/zend-escaper": "^2.5",
+                "zendframework/zend-validator": "^2.10"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.4",
+                "zendframework/zend-coding-standard": "~1.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7.x-dev",
+                    "dev-develop": "2.8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Uri\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "A component that aids in manipulating and validating » Uniform Resource Identifiers (URIs)",
+            "keywords": [
+                "ZendFramework",
+                "uri",
+                "zf"
+            ],
+            "time": "2020-07-23T08:35:51+00:00"
+        },
+        {
+            "name": "zendframework/zend-validator",
+            "version": "2.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-validator.git",
+                "reference": "b54acef1f407741c5347f2a97f899ab21f2229ef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-validator/zipball/b54acef1f407741c5347f2a97f899ab21f2229ef",
+                "reference": "b54acef1f407741c5347f2a97f899ab21f2229ef",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "^1.1",
+                "php": "^7.1",
+                "zendframework/zend-stdlib": "^3.2.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0.8 || ^5.7.15",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.0",
+                "zendframework/zend-cache": "^2.6.1",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-config": "^2.6",
+                "zendframework/zend-db": "^2.7",
+                "zendframework/zend-filter": "^2.6",
+                "zendframework/zend-http": "^2.5.4",
+                "zendframework/zend-i18n": "^2.6",
+                "zendframework/zend-math": "^2.6",
+                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
+                "zendframework/zend-session": "^2.8",
+                "zendframework/zend-uri": "^2.5"
+            },
+            "suggest": {
+                "psr/http-message": "psr/http-message, required when validating PSR-7 UploadedFileInterface instances via the Upload and UploadFile validators",
+                "zendframework/zend-db": "Zend\\Db component, required by the (No)RecordExists validator",
+                "zendframework/zend-filter": "Zend\\Filter component, required by the Digits validator",
+                "zendframework/zend-i18n": "Zend\\I18n component to allow translation of validation error messages",
+                "zendframework/zend-i18n-resources": "Translations of validator messages",
+                "zendframework/zend-math": "Zend\\Math component, required by the Csrf validator",
+                "zendframework/zend-servicemanager": "Zend\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",
+                "zendframework/zend-session": "Zend\\Session component, ^2.8; required by the Csrf validator",
+                "zendframework/zend-uri": "Zend\\Uri component, required by the Uri and Sitemap\\Loc validators"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.13.x-dev",
+                    "dev-develop": "2.14.x-dev"
+                },
+                "zf": {
+                    "component": "Zend\\Validator",
+                    "config-provider": "Zend\\Validator\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Validator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Validation classes for a wide range of domains, and the ability to chain validators to create complex validation criteria",
+            "keywords": [
+                "ZendFramework",
+                "validator",
+                "zf"
+            ],
+            "abandoned": "laminas/laminas-validator",
+            "time": "2019-12-28T04:07:18+00:00"
         }
     ],
     "packages-dev": [

--- a/docs/http-documentation.md
+++ b/docs/http-documentation.md
@@ -2,10 +2,8 @@
 
 ## Table of Contents
 
-- [HTTP Documentation](#http-documentation)
-  - [Table of Contents](#table-of-contents)
-  - [Purpose of the HTTP Client](#purpose-of-the-http-client)
-  - [Example HTTP Client Implementations](#example-http-client-implementations)
+- [Purpose of the HTTP Client](#purpose-of-the-http-client)
+- [Example HTTP Client Implementations](#example-http-client-implementations)
 
 ## Purpose of the HTTP Client
 
@@ -70,17 +68,17 @@ $httpClient->put('endpoint/put', [
 $httpClient->delete('endpoint/delete', ['record_id' => 'sample_id_value']);
 ```
 
-The HTTP client also supports custom HTTP clients based off of the Laminas Client
+The HTTP client also supports custom HTTP clients based off of the Zend Client
 when initializing the client object such as this:
 
 ```php
 <?php
 declare(strict_types=1);
 use NS8\ProtectSDK\Http\Client as HttpClient;
-use Laminas\Http\Client as LaminasClient;
-use Laminas\Http\Client\Adapter\Test as LaminasTestAdapter;
-$adapter = new LaminasTestAdapter();
-$testHttpClient = new LaminasClient('ns8.com', ['adapter' => $adapter]);
+use Zend\Http\Client as ZendClient;
+use Zend\Http\Client\Adapter\Test as ZendTestAdapter;
+$adapter = new ZendTestAdapter();
+$testHttpClient = new ZendClient('ns8.com', ['adapter' => $adapter]);
 // The third argument "true" lets the NS8 HTTP client know to automatically set
 // session data for HTTP requests
 $httpClient = new Client('test', 'test', true, $testHttpClient);

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace NS8\ProtectSDK\Http;
 
-use Laminas\Http\Client as LaminasClient;
-use Laminas\Http\PhpEnvironment\RemoteAddress as LaminasRemoteAddress;
-use Laminas\Json\Decoder as LaminasJsonDecoder;
 use NS8\ProtectSDK\Config\Manager as ConfigManager;
 use NS8\ProtectSDK\Http\Exceptions\Http as HttpException;
 use NS8\ProtectSDK\Logging\Client as LoggingClient;
@@ -14,6 +11,9 @@ use NS8\ProtectSDK\Logging\Handlers\Api as ApiHandler;
 use NS8\ProtectSDK\Security\Client as SecurityClient;
 use stdClass;
 use Throwable;
+use Zend\Http\Client as ZendClient;
+use Zend\Http\PhpEnvironment\RemoteAddress as ZendRemoteAddress;
+use Zend\Json\Decoder as ZendJsonDecoder;
 use function array_merge;
 use function in_array;
 use function sprintf;
@@ -54,7 +54,7 @@ class Client implements IProtectClient
     /**
      * HTTP Library Client attribute
      *
-     * @var Laminas\Http\Client
+     * @var Zend\Http\Client
      */
     protected $client;
 
@@ -107,7 +107,7 @@ class Client implements IProtectClient
      * @param ?string        $authUsername   Authentication username for NS8 requests
      * @param ?string        $accessToken    Access Token for NS8 requests
      * @param bool           $setSessionData Determines if the class instance should set session data to pass to NS8
-     * @param ?LaminasClient $client         HTTP client to use when making requests
+     * @param ?ZendClient    $client         HTTP client to use when making requests
      * @param ?ConfigManager $configManager  Configuration Manager used by the client for fetching request info
      * @param ?LoggingClient $loggingClient  Logging client used for recording request data
      */
@@ -115,11 +115,11 @@ class Client implements IProtectClient
         ?string $authUsername = null,
         ?string $accessToken = null,
         bool $setSessionData = true,
-        ?LaminasClient $client = null,
+        ?ZendClient $client = null,
         ?ConfigManager $configManager = null,
         ?LoggingClient $loggingClient = null
     ) {
-        $this->client        = $client ?? new LaminasClient();
+        $this->client        = $client ?? new ZendClient();
         $this->configManager = $configManager ?? new ConfigManager();
         $this->loggingClient = $loggingClient ?? new LoggingClient();
 
@@ -143,7 +143,7 @@ class Client implements IProtectClient
         }
 
         $this->setSessionData([
-            'ip' => (new LaminasRemoteAddress())->getIpAddress(),
+            'ip' => (new ZendRemoteAddress())->getIpAddress(),
             'acceptLanguage' => $_SERVER['HTTP_ACCEPT_LANGUAGE'] ?? null,
             'userAgent' => $_SERVER['HTTP_USER_AGENT'] ?? null,
         ]);
@@ -311,7 +311,7 @@ class Client implements IProtectClient
     ) : stdClass {
         $body = $this->executeRequest($route, $data, $method, $parameters, $headers, $timeout);
 
-        return LaminasJsonDecoder::decode($body);
+        return ZendJsonDecoder::decode($body);
     }
 
     /**

--- a/src/Queue/BaseClient.php
+++ b/src/Queue/BaseClient.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace NS8\ProtectSDK\Queue;
 
-use Laminas\Http\Client as LaminasClient;
+use Zend\Http\Client as ZendClient;
 
 /**
  * Manage updates from Queue for order info
@@ -14,11 +14,11 @@ abstract class BaseClient
     /**
      * Initializes the class to ensure attributes are set up correctly.
      *
-     * @param LaminasClient $httpClient The HTTP client used to make requests
+     * @param ZendClient $httpClient The HTTP client used to make requests
      *
      * @return void
      */
-    abstract public static function initialize(?LaminasClient $httpClient = null) : void;
+    abstract public static function initialize(?ZendClient $httpClient = null) : void;
 
     /**
      * Returns the URL being used for queue iteration during runtime

--- a/src/Queue/Client.php
+++ b/src/Queue/Client.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace NS8\ProtectSDK\Queue;
 
-use Laminas\Http\Client as LaminasClient;
 use NS8\ProtectSDK\Http\Client as NS8HttpClient;
 use NS8\ProtectSDK\Queue\Exceptions\Decoding as DecodingException;
 use NS8\ProtectSDK\Queue\Exceptions\Response as ResponseException;
+use Zend\Http\Client as ZendClient;
 use function array_key_exists;
 use function http_build_query;
 use function json_decode;
@@ -29,7 +29,7 @@ class Client extends BaseClient
     /**
      * Attribute to track HTTTP Client used for sending requests
      *
-     * @var LaminasClient $httpClient
+     * @var ZendClient $httpClient
      */
     protected static $httpClient;
 
@@ -80,15 +80,15 @@ class Client extends BaseClient
     /**
      * Initializes the class to ensure attributes are set up correctly.
      *
-     * @param LaminasClient $httpClient The HTTP client used to make requests
-     * @param string        $queueUrl   URL used to access queue
+     * @param ZendClient $httpClient The HTTP client used to make requests
+     * @param string     $queueUrl   URL used to access queue
      *
      * @return void
      */
-    public static function initialize(?LaminasClient $httpClient = null, ?string $queueUrl = null) : void
+    public static function initialize(?ZendClient $httpClient = null, ?string $queueUrl = null) : void
     {
         self::$url        = $queueUrl;
-        self::$httpClient = $httpClient ?? new LaminasClient();
+        self::$httpClient = $httpClient ?? new ZendClient();
     }
 
     /**

--- a/tests/Actions/ClientTest.php
+++ b/tests/Actions/ClientTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace NS8\ProtectSDK\Tests\Actions;
 
-use Laminas\Http\Client as LaminasClient;
-use Laminas\Http\Client\Adapter\Test as LaminasTestAdapter;
 use NS8\ProtectSDK\Actions\Client as ActionClient;
 use NS8\ProtectSDK\Config\Manager as ConfigManager;
 use NS8\ProtectSDK\Http\Client as HttpClient;
 use PHPUnit\Framework\TestCase;
+use Zend\Http\Client as ZendClient;
+use Zend\Http\Client\Adapter\Test as ZendTestAdapter;
 
 /**
  * Actions Test Class
@@ -206,14 +206,14 @@ class ClientTest extends TestCase
     }
 
     /**
-     * Returns a test Laminas HTTP client to utilize when invoking the NS8 Core HTTP Client
+     * Returns a test Zend HTTP client to utilize when invoking the NS8 Core HTTP Client
      *
-     * @return LaminasClient
+     * @return ZendClient
      */
-    protected function buildTestHttpClient() : LaminasClient
+    protected function buildTestHttpClient() : ZendClient
     {
-        $adapter        = new LaminasTestAdapter();
-        $testHttpClient = new LaminasClient('', ['adapter' => $adapter]);
+        $adapter        = new ZendTestAdapter();
+        $testHttpClient = new ZendClient('', ['adapter' => $adapter]);
 
         $response =  'HTTP/1.1 200 OK' . "\n" .
         'Content-type: application/json' . "\n\n" .

--- a/tests/Http/ClientTest.php
+++ b/tests/Http/ClientTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace NS8\ProtectSDK\Tests\Http;
 
-use Laminas\Http\Client as LaminasClient;
-use Laminas\Http\Client\Adapter\Exception\RuntimeException as LaminasRuntimeException;
-use Laminas\Http\Client\Adapter\Test as LaminasTestAdapter;
 use NS8\ProtectSDK\Config\Manager as ConfigManager;
 use NS8\ProtectSDK\Http\Client;
 use NS8\ProtectSDK\Http\Exceptions\Http as HttpException;
 use PHPUnit\Framework\TestCase;
+use Zend\Http\Client as ZendClient;
+use Zend\Http\Client\Adapter\Exception\RuntimeException as ZendRuntimeException;
+use Zend\Http\Client\Adapter\Test as ZendTestAdapter;
 use function sprintf;
 
 /**
@@ -242,7 +242,7 @@ class ClientTest extends TestCase
             $testHttpClient,
             self::$configManager
         );
-        $this->expectException(LaminasRuntimeException::class);
+        $this->expectException(ZendRuntimeException::class);
         $response = $client->sendNonObjectRequest(self::TEST_URI);
     }
 
@@ -898,16 +898,16 @@ class ClientTest extends TestCase
     }
 
     /**
-     * Returns a test Laminas HTTP client to utilize when invoking the NS8 Core HTTP Client
+     * Returns a test Zend HTTP client to utilize when invoking the NS8 Core HTTP Client
      *
      * @param string $requestType Request type being sent
      *
-     * @return LaminasClient
+     * @return ZendClient
      */
-    protected function buildTestHttpClient(string $requestType) : LaminasClient
+    protected function buildTestHttpClient(string $requestType) : ZendClient
     {
-        $adapter        = new LaminasTestAdapter();
-        $testHttpClient = new LaminasClient(self::TEST_URI, ['adapter' => $adapter]);
+        $adapter        = new ZendTestAdapter();
+        $testHttpClient = new ZendClient(self::TEST_URI, ['adapter' => $adapter]);
 
         $response =  'HTTP/1.1 200 OK' . "\n" .
         'Content-type: application/json' . "\n\n" .
@@ -922,18 +922,18 @@ class ClientTest extends TestCase
     }
 
     /**
-     * Returns a test Laminas HTTP client to utilize when invoking the NS8 Core HTTP Client
+     * Returns a test Zend HTTP client to utilize when invoking the NS8 Core HTTP Client
      * for Non-JSON requests
      *
      * @param bool $triggerFailure Sets if the HTTP client should fail in the request
      *
-     * @return LaminasClient
+     * @return ZendClient
      */
-    protected function buildTestNonJsonHttpClient(bool $triggerFailure = false) : LaminasClient
+    protected function buildTestNonJsonHttpClient(bool $triggerFailure = false) : ZendClient
     {
-        $adapter = new LaminasTestAdapter();
+        $adapter = new ZendTestAdapter();
         $adapter->setNextRequestWillFail($triggerFailure);
-        $testHttpClient = new LaminasClient(self::TEST_URI, ['adapter' => $adapter]);
+        $testHttpClient = new ZendClient(self::TEST_URI, ['adapter' => $adapter]);
 
         $response =  'HTTP/1.1 200 OK' . "\n" .
         'Content-type: text/html' . "\n\n" .

--- a/tests/Installer/ClientTest.php
+++ b/tests/Installer/ClientTest.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace NS8\ProtectSDK\Tests\Installer;
 
-use Laminas\Http\Client as LaminasClient;
-use Laminas\Http\Client\Adapter\Test as LaminasTestAdapter;
 use NS8\ProtectSDK\Config\Manager as ConfigManager;
 use NS8\ProtectSDK\Http\Client as HttpClient;
 use NS8\ProtectSDK\Installer\Client as InstallerClient;
 use NS8\ProtectSDK\Installer\Exceptions\MissingData as MissingDataException;
 use NS8\ProtectSDK\Installer\Exceptions\RequestFailed as RequestFailedException;
 use PHPUnit\Framework\TestCase;
+use Zend\Http\Client as ZendClient;
+use Zend\Http\Client\Adapter\Test as ZendTestAdapter;
 use function json_encode;
 use function sprintf;
 
@@ -301,7 +301,7 @@ class ClientTest extends TestCase
     }
 
     /**
-     * Returns a test Laminas HTTP client to utilize when testing successful outputs
+     * Returns a test Zend HTTP client to utilize when testing successful outputs
      *
      * @param mixed[] $data Array of data that should be present in JSON
      *
@@ -309,8 +309,8 @@ class ClientTest extends TestCase
      */
     protected function buildTestHttpClient(array $data) : HttpClient
     {
-        $adapter        = new LaminasTestAdapter();
-        $testHttpClient = new LaminasClient(
+        $adapter        = new ZendTestAdapter();
+        $testHttpClient = new ZendClient(
             sprintf(InstallerClient::INSTALL_ENDPOINT, 'magento'),
             ['adapter' => $adapter]
         );

--- a/tests/Logging/Handlers/ApiTest.php
+++ b/tests/Logging/Handlers/ApiTest.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace NS8\ProtectSDK\Tests\Logging\Handlers;
 
 use Exception;
-use Laminas\Http\Client as LaminasClient;
-use Laminas\Http\Client\Adapter\Test as LaminasTestAdapter;
 use NS8\ProtectSDK\Config\Manager as ConfigManager;
 use NS8\ProtectSDK\Http\Client as HttpClient;
 use NS8\ProtectSDK\Logging\Client as LoggingClient;
 use NS8\ProtectSDK\Logging\Handlers\Api as ApiHandler;
 use PHPUnit\Framework\TestCase;
 use Throwable;
+use Zend\Http\Client as ZendClient;
+use Zend\Http\Client\Adapter\Test as ZendTestAdapter;
 
 /**
  * Logging Client Test Class
@@ -196,12 +196,12 @@ class ApiTest extends TestCase
     /**
      * Return HTTP client that will fail all requests
      *
-     * @return LaminasClient HTTP client to be used in NS8 HTTP client set-up
+     * @return ZendClient HTTP client to be used in NS8 HTTP client set-up
      */
-    protected function getFailureClient() : LaminasClient
+    protected function getFailureClient() : ZendClient
     {
-        $adapter = new LaminasTestAdapter();
-        $adapter = new class extends LaminasTestAdapter {
+        $adapter = new ZendTestAdapter();
+        $adapter = new class extends ZendTestAdapter {
             /**
              * Overrides connect function to gurantee connection will always fail
              *
@@ -224,6 +224,6 @@ class ApiTest extends TestCase
         "}\n";
         $adapter->setResponse($response);
 
-        return new LaminasClient('/path', ['adapter' => $adapter]);
+        return new ZendClient('/path', ['adapter' => $adapter]);
     }
 }

--- a/tests/Queue/ClientTest.php
+++ b/tests/Queue/ClientTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace NS8\ProtectSDK\Tests\Queue;
 
-use Laminas\Http\Client as LaminasClient;
-use Laminas\Http\Client\Adapter\Test as LaminasTestAdapter;
 use NS8\ProtectSDK\Http\Client as HttpClient;
 use NS8\ProtectSDK\Queue\Client as QueueClient;
 use NS8\ProtectSDK\Queue\Exceptions\Decoding as DecodingException;
 use NS8\ProtectSDK\Queue\Exceptions\Response as ResponseException;
 use PHPUnit\Framework\TestCase;
+use Zend\Http\Client as ZendClient;
+use Zend\Http\Client\Adapter\Test as ZendTestAdapter;
 use function json_decode;
 use function json_encode;
 
@@ -465,16 +465,16 @@ class ClientTest extends TestCase
     }
 
     /**
-     * Returns a test Laminas HTTP client to utilize when testing successful outputs
+     * Returns a test Zend HTTP client to utilize when testing successful outputs
      *
      * @param mixed[] $data Array of data that should be present in JSON
      *
-     * @return LaminasClient
+     * @return ZendClient
      */
-    protected function buildTestSuccessHttpClient(array $data) : LaminasClient
+    protected function buildTestSuccessHttpClient(array $data) : ZendClient
     {
-        $adapter        = new LaminasTestAdapter();
-        $testHttpClient = new LaminasClient(self::TEST_URI, ['adapter' => $adapter]);
+        $adapter        = new ZendTestAdapter();
+        $testHttpClient = new ZendClient(self::TEST_URI, ['adapter' => $adapter]);
 
         $response =  'HTTP/1.1 200 OK' . "\n" .
         'Content-type: application/json' . "\n\n" .
@@ -487,14 +487,14 @@ class ClientTest extends TestCase
     }
 
     /**
-     * Returns a test Laminas HTTP client when expecting an error message
+     * Returns a test Zend HTTP client when expecting an error message
      *
-     * @return LaminasClient
+     * @return ZendClient
      */
-    protected function buildTestExceptionHttpClient() : LaminasClient
+    protected function buildTestExceptionHttpClient() : ZendClient
     {
-        $adapter        = new LaminasTestAdapter();
-        $testHttpClient = new LaminasClient(self::TEST_URI, ['adapter' => $adapter]);
+        $adapter        = new ZendTestAdapter();
+        $testHttpClient = new ZendClient(self::TEST_URI, ['adapter' => $adapter]);
 
         $response =  'HTTP/1.1 200 OK' . "\n" .
         'Content-type: application/json' . "\n\n" .
@@ -514,14 +514,14 @@ class ClientTest extends TestCase
     }
 
     /**
-     * Returns a test Laminas HTTP client to test invalid JSON responses
+     * Returns a test Zend HTTP client to test invalid JSON responses
      *
-     * @return LaminasClient
+     * @return ZendClient
      */
-    protected function buildInvalidJsonHttpClient() : LaminasClient
+    protected function buildInvalidJsonHttpClient() : ZendClient
     {
-        $adapter        = new LaminasTestAdapter();
-        $testHttpClient = new LaminasClient(self::TEST_URI, ['adapter' => $adapter]);
+        $adapter        = new ZendTestAdapter();
+        $testHttpClient = new ZendClient(self::TEST_URI, ['adapter' => $adapter]);
 
         $response =  'HTTP/1.1 200 OK' . "\n" .
         'Content-type: text/html' . "\n\n" .
@@ -541,8 +541,8 @@ class ClientTest extends TestCase
      */
     protected function buildNS8HttpClient(array $jsonData) : HttpClient
     {
-        $adapter        = new LaminasTestAdapter();
-        $testHttpClient = new LaminasClient('', ['adapter' => $adapter]);
+        $adapter        = new ZendTestAdapter();
+        $testHttpClient = new ZendClient('', ['adapter' => $adapter]);
 
         $response =  'HTTP/1.1 200 OK' . "\n" .
         'Content-type: application/json' . "\n\n" .


### PR DESCRIPTION
# Story Reference

[ch38251](https://app.clubhouse.io/ns8/story/38251/resolve-laminas-library-issues)

## Summary

This replaces https://github.com/ns8inc/protect-sdk-php/pull/100 and fixes conflicts in `composer.lock`.

## Author Checklist

I have added/updated:

- [ ] Tests
- [ ] Documentation
- [X] Release notes (title of this PR)

## Version Bump

- [X] Patch (bug fix - backwards compatible)
- [ ] Minor (new functionality - backwards compatible)
- [ ] Major (significant change - not backwards compatible)
