### PR TITLE
changes for PHP 7.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "codeception/aspect-mock": "^3.0.2"
     },
     "scripts": {
-        "lint": "phpcs --extensions=php src/ tests/ && yarn global add markdownlint-cli && markdownlint . --ignore vendor/",
+        "lint": "phpcs -s --extensions=php src/ tests/ && yarn global add markdownlint-cli && markdownlint . --ignore vendor/",
         "lint-fix": "phpcbf --extensions=php src/ tests/ && yarn global add markdownlint-cli && markdownlint . --fix --ignore vendor/",
         "test": "phpunit tests/",
         "test-coverage": "phpunit --coverage-clover coverage/clover.xml --coverage-html coverage/html --coverage-text --log-junit coverage/junit.xml tests/ && coverage-check coverage/clover.xml 100"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -5,6 +5,9 @@
     <!-- We use (almost) all of the Doctrine rules. -->
     <rule ref="Doctrine">
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.UselessReturnAnnotation"/>
+        <exclude name="SlevomatCodingStandard.Classes.ClassConstantVisibility.MissingConstantVisibility" />
+        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint" />
+        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint" />
     </rule>
 
     <!-- Doctrine doesn't care too much about docblocks, so we use (most of) PEAR's rules for that. -->
@@ -21,6 +24,6 @@
 
     <!-- Check for deprecated/removed PHP functions. -->
     <rule ref="PHPCompatibility">
-        <config name="testVersion" value="7.1-"/>
+        <config name="testVersion" value="7.0-"/>
     </rule>
 </ruleset>

--- a/src/Actions/BaseClient.php
+++ b/src/Actions/BaseClient.php
@@ -12,29 +12,29 @@ abstract class BaseClient
     /**
      * Known events for the NS8 Platform
      */
-    public const DEFAULT_FLOW_COMPLETED_EVENT              = 'DEFAULT_FLOW_COMPLETED_EVENT';
-    public const ON_DISABLE_EXTENSION_EVENT                = 'ON_DISABLE_EXTENSION_EVENT';
-    public const ON_ENABLE_EXTENSION_EVENT                 = 'ON_ENABLE_EXTENSION_EVENT';
-    public const ON_INSTALL_PLATFORM_EVENT                 = 'ON_INSTALL_PLATFORM_EVENT';
-    public const ON_UPDATE_EXTENSION_EVENT                 = 'ON_UPDATE_EXTENSION_EVENT';
-    public const ORDER_READY_EVENT                         = 'ORDER_READY_EVENT';
-    public const PAYMENT_DECORATED_EVENT                   = 'PAYMENT_DECORATED_EVENT';
-    public const PAYMENT_SCORED_EVENT                      = 'PAYMENT_SCORED_EVENT';
-    public const SESSION_DECORATED_EVENT                   = 'SESSION_DECORATED_EVENT';
-    public const SESSION_SCORED_EVENT                      = 'SESSION_SCORED_EVENT';
-    public const UPDATE_CUSTOMER_VERIFICATION_STATUS_EVENT = 'UPDATE_CUSTOMER_VERIFICATION_STATUS_EVENT';
-    public const UPDATE_EQ8_SCORE_EVENT                    = 'UPDATE_EQ8_SCORE_EVENT';
-    public const UPDATE_ORDER_RISK_EVENT                   = 'UPDATE_ORDER_RISK_EVENT';
-    public const UPDATE_ORDER_STATUS_EVENT                 = 'UPDATE_ORDER_STATUS_EVENT';
+    const DEFAULT_FLOW_COMPLETED_EVENT              = 'DEFAULT_FLOW_COMPLETED_EVENT';
+    const ON_DISABLE_EXTENSION_EVENT                = 'ON_DISABLE_EXTENSION_EVENT';
+    const ON_ENABLE_EXTENSION_EVENT                 = 'ON_ENABLE_EXTENSION_EVENT';
+    const ON_INSTALL_PLATFORM_EVENT                 = 'ON_INSTALL_PLATFORM_EVENT';
+    const ON_UPDATE_EXTENSION_EVENT                 = 'ON_UPDATE_EXTENSION_EVENT';
+    const ORDER_READY_EVENT                         = 'ORDER_READY_EVENT';
+    const PAYMENT_DECORATED_EVENT                   = 'PAYMENT_DECORATED_EVENT';
+    const PAYMENT_SCORED_EVENT                      = 'PAYMENT_SCORED_EVENT';
+    const SESSION_DECORATED_EVENT                   = 'SESSION_DECORATED_EVENT';
+    const SESSION_SCORED_EVENT                      = 'SESSION_SCORED_EVENT';
+    const UPDATE_CUSTOMER_VERIFICATION_STATUS_EVENT = 'UPDATE_CUSTOMER_VERIFICATION_STATUS_EVENT';
+    const UPDATE_EQ8_SCORE_EVENT                    = 'UPDATE_EQ8_SCORE_EVENT';
+    const UPDATE_ORDER_RISK_EVENT                   = 'UPDATE_ORDER_RISK_EVENT';
+    const UPDATE_ORDER_STATUS_EVENT                 = 'UPDATE_ORDER_STATUS_EVENT';
 
     /**
      * Known actions for ther NS8 Platform
      */
-    public const CREATE_ORDER_ACTION        = 'CREATE_ORDER_ACTION';
-    public const UNINSTALL_ACTION           = 'UNINSTALL_ACTION';
-    public const UPDATE_MERCHANT_ACTION     = 'UPDATE_MERCHANT_ACTION';
-    public const UPDATE_ORDER_STATUS_ACTION = 'UPDATE_ORDER_STATUS_ACTION';
-    public const WEBHOOK_ACTION             = 'WEBHOOK_ACTION';
+    const CREATE_ORDER_ACTION        = 'CREATE_ORDER_ACTION';
+    const UNINSTALL_ACTION           = 'UNINSTALL_ACTION';
+    const UPDATE_MERCHANT_ACTION     = 'UPDATE_MERCHANT_ACTION';
+    const UPDATE_ORDER_STATUS_ACTION = 'UPDATE_ORDER_STATUS_ACTION';
+    const WEBHOOK_ACTION             = 'WEBHOOK_ACTION';
 
     /**
      * A list of predefined NS8 events to serve enumeration/validation purposes

--- a/src/Actions/Client.php
+++ b/src/Actions/Client.php
@@ -14,17 +14,17 @@ class Client extends BaseClient
     /**
      * Response code for successful action setting
      */
-    public const ACTION_SUCCESS_CODE = 200;
+    const ACTION_SUCCESS_CODE = 200;
 
     /**
      * API path for Switch Executor
      */
-    public const SWITCH_EXECUTOR_PATH = '/switch/executor';
+    const SWITCH_EXECUTOR_PATH = '/switch/executor';
 
     /**
      * Action key used for switch actions
      */
-    public const ACTION_KEY = 'action';
+    const ACTION_KEY = 'action';
 
     /**
      * HTTP Client used to make API requests
@@ -52,7 +52,7 @@ class Client extends BaseClient
       *
       * @return void
       */
-    public static function setHttpClient(HttpClient $httpClient) : void
+    public static function setHttpClient(HttpClient $httpClient)
     {
         self::$httpClient = $httpClient;
     }

--- a/src/Analytics/Client.php
+++ b/src/Analytics/Client.php
@@ -24,19 +24,19 @@ class Client extends BaseClient
     /**
      * POST route for fetching TrueStats script from NS8
      */
-    public const TRUE_STATS_ROUTE = '/init/script';
+    const TRUE_STATS_ROUTE = '/init/script';
 
     /**
      * The temporary file used for caching the TrueStats script.
      *
      * "%u" gets replaced with the individual store ID.
      */
-    protected const TRUE_STATS_CACHE_FILE = 'ns8-truestats-%u.js';
+    const TRUE_STATS_CACHE_FILE = 'ns8-truestats-%u.js';
 
     /**
      * The TrueStats script gets cached for 1 day
      */
-    protected const TRUE_STATS_CACHE_TTL = 86400;
+    const TRUE_STATS_CACHE_TTL = 86400;
 
     /**
      * HTTP Client used to make API requests
@@ -98,7 +98,7 @@ class Client extends BaseClient
       *
       * @return void
       */
-    public static function setHttpClient(HttpClient $httpClient) : void
+    public static function setHttpClient(HttpClient $httpClient)
     {
         self::$httpClient = $httpClient;
     }
@@ -120,7 +120,7 @@ class Client extends BaseClient
      *
      * @return string|null The cached script
      */
-    protected static function getScriptFromCache() : ?string
+    protected static function getScriptFromCache()
     {
         $file = self::getFullPathToScriptCacheFile();
 
@@ -140,7 +140,7 @@ class Client extends BaseClient
      *
      * @return void
      */
-    protected static function saveScriptToCache(string $script) : void
+    protected static function saveScriptToCache(string $script)
     {
         file_put_contents(self::getFullPathToScriptCacheFile(), $script);
     }

--- a/src/ClientSdk/Client.php
+++ b/src/ClientSdk/Client.php
@@ -14,10 +14,10 @@ class Client extends BaseClient
     /**
      * Enum values that correspond to `ClientPage` in the Protect Client SDK
      */
-    public const CLIENT_PAGE_DASHBOARD         = 'DASHBOARD';
-    public const CLIENT_PAGE_ORDER_DETAILS     = 'ORDER_DETAILS';
-    public const CLIENT_PAGE_ORDER_RULES       = 'ORDER_RULES';
-    public const CLIENT_PAGE_SUSPICIOUS_ORDERS = 'SUSPICIOUS_ORDERS';
+    const CLIENT_PAGE_DASHBOARD         = 'DASHBOARD';
+    const CLIENT_PAGE_ORDER_DETAILS     = 'ORDER_DETAILS';
+    const CLIENT_PAGE_ORDER_RULES       = 'ORDER_RULES';
+    const CLIENT_PAGE_SUSPICIOUS_ORDERS = 'SUSPICIOUS_ORDERS';
 
     /**
      * Returns Client SDK URL

--- a/src/Config/Manager.php
+++ b/src/Config/Manager.php
@@ -21,7 +21,7 @@ class Manager extends ManagerStructure
     /**
      * Rules based on key pattern to prevent overriding specific environment values
      */
-    public const SET_VALUE_PREVENTION_RULES =
+    const SET_VALUE_PREVENTION_RULES =
         ['/^(production|testing)\\' . self::KEY_DELIMITER . 'urls\\' . self::KEY_DELIMITER . '.*/'];
 
     /**
@@ -177,7 +177,7 @@ class Manager extends ManagerStructure
      *
      * @return void
      */
-    protected static function setRuntimeConfigValues() : void
+    protected static function setRuntimeConfigValues()
     {
         foreach (self::STATIC_CONFIG_MAPPINGS as $key => $value) {
             self::setValueWithoutValidation($key, $value);

--- a/src/Config/ManagerStructure.php
+++ b/src/Config/ManagerStructure.php
@@ -26,20 +26,20 @@ abstract class ManagerStructure
     /**
      * Delimiter used in key parsing (e.g. "production.urls.api_url")
      */
-    public const KEY_DELIMITER = '.';
+    const KEY_DELIMITER = '.';
 
     /**
      * Core configuration file name
      */
-    public const DEFAULT_CONFIG_FILE = 'core_configuration.json';
+    const DEFAULT_CONFIG_FILE = 'core_configuration.json';
 
     /**
      * Constants related to what defines an environment value as valid
      */
-    public const ENV_PRODUCTION               = 'production';
-    public const ENV_TESTING                  = 'testing';
-    public const ENV_DEVELOPMENT              = 'development';
-    public const ACCEPTED_CONFIG_ENVIRONMENTS = [
+    const ENV_PRODUCTION               = 'production';
+    const ENV_TESTING                  = 'testing';
+    const ENV_DEVELOPMENT              = 'development';
+    const ACCEPTED_CONFIG_ENVIRONMENTS = [
         self::ENV_PRODUCTION,
         self::ENV_TESTING,
         self::ENV_DEVELOPMENT,
@@ -48,33 +48,33 @@ abstract class ManagerStructure
     /**
      * Production URLs that should remain static in configuration
      */
-    public const PRODUCTION_API_URL_KEY      = self::ENV_PRODUCTION . self::KEY_DELIMITER
+    const PRODUCTION_API_URL_KEY      = self::ENV_PRODUCTION . self::KEY_DELIMITER
         . 'urls' . self::KEY_DELIMITER . 'api_url';
-    public const PRODUCTION_API_URL_VALUE    = 'https://protect.ns8.com';
-    public const PRODUCTION_CLIENT_URL_KEY   = self::ENV_PRODUCTION . self::KEY_DELIMITER
+    const PRODUCTION_API_URL_VALUE    = 'https://protect.ns8.com';
+    const PRODUCTION_CLIENT_URL_KEY   = self::ENV_PRODUCTION . self::KEY_DELIMITER
         . 'urls' . self::KEY_DELIMITER . 'client_url';
-    public const PRODUCTION_CLIENT_URL_VALUE = 'https://protect-client.ns8.com';
-    public const PRODUCTION_CLIENT_SDK_KEY   = self::ENV_PRODUCTION . self::KEY_DELIMITER
+    const PRODUCTION_CLIENT_URL_VALUE = 'https://protect-client.ns8.com';
+    const PRODUCTION_CLIENT_SDK_KEY   = self::ENV_PRODUCTION . self::KEY_DELIMITER
         . 'urls' . self::KEY_DELIMITER . 'js_sdk';
-    public const PRODUCTION_CLIENT_SDK_VALUE = 'https://d3hfiwqcryy9cp.cloudfront.net/assets/js/protect.min.js';
+    const PRODUCTION_CLIENT_SDK_VALUE = 'https://d3hfiwqcryy9cp.cloudfront.net/assets/js/protect.min.js';
 
     /**
      * Testing URLs that should remain static in configuration
      */
-    public const TESTING_API_URL_KEY      = self::ENV_TESTING . self::KEY_DELIMITER
+    const TESTING_API_URL_KEY      = self::ENV_TESTING . self::KEY_DELIMITER
         . 'urls' . self::KEY_DELIMITER . 'api_url';
-    public const TESTING_API_URL_VALUE    = 'https://test-protect.ns8.com';
-    public const TESTING_CLIENT_URL_KEY   = self::ENV_TESTING . self::KEY_DELIMITER
+    const TESTING_API_URL_VALUE    = 'https://test-protect.ns8.com';
+    const TESTING_CLIENT_URL_KEY   = self::ENV_TESTING . self::KEY_DELIMITER
         . 'urls' . self::KEY_DELIMITER . 'client_url';
-    public const TESTING_CLIENT_URL_VALUE = 'https://test-protect-client.ns8.com';
-    public const TESTING_JS_SDK_KEY       = self::ENV_TESTING . self::KEY_DELIMITER
+    const TESTING_CLIENT_URL_VALUE = 'https://test-protect-client.ns8.com';
+    const TESTING_JS_SDK_KEY       = self::ENV_TESTING . self::KEY_DELIMITER
         . 'urls' . self::KEY_DELIMITER . 'js_sdk';
-    public const TESTING_JS_SDK_VALUE     = 'https://d3hfiwqcryy9cp.cloudfront.net/assets/js/protect-dev.min.js';
+    const TESTING_JS_SDK_VALUE     = 'https://d3hfiwqcryy9cp.cloudfront.net/assets/js/protect-dev.min.js';
 
     /**
      * Fields that must be set for requests
      */
-    public const ENV_REQUIRED_FIELDS = [
+    const ENV_REQUIRED_FIELDS = [
         'urls' . self::KEY_DELIMITER . 'api_url',
         'urls' . self::KEY_DELIMITER . 'client_url',
     ];
@@ -82,7 +82,7 @@ abstract class ManagerStructure
     /**
      * Mapping of keys/values that should remain static in configuration
      */
-    public const STATIC_CONFIG_MAPPINGS = [
+    const STATIC_CONFIG_MAPPINGS = [
         self::PRODUCTION_API_URL_KEY => self::PRODUCTION_API_URL_VALUE,
         self::PRODUCTION_CLIENT_URL_KEY => self::PRODUCTION_CLIENT_URL_VALUE,
         self::PRODUCTION_CLIENT_SDK_KEY => self::PRODUCTION_CLIENT_SDK_VALUE,
@@ -125,12 +125,12 @@ abstract class ManagerStructure
      * @throws EnvironmentConfigException if the environment type initialized is not valid.
      */
     public static function initConfiguration(
-        ?string $environment = null,
-        ?string $customConfigJsonFile = null,
-        ?string $baseConfigJsonFile = null,
-        ?string $platformVersion = null,
-        ?string $phpVersion = null
-    ) : void {
+        $environment = null,
+        $customConfigJsonFile = null,
+        $baseConfigJsonFile = null,
+        $platformVersion = null,
+        $phpVersion = null
+    ) {
         if (self::$configInitialized) {
             return;
         }
@@ -173,7 +173,7 @@ abstract class ManagerStructure
      *
      * @return void
      */
-    public static function resetConfig() : void
+    public static function resetConfig()
     {
         self::$configInitialized = false;
         self::$configData        = [];
@@ -223,7 +223,7 @@ abstract class ManagerStructure
      *
      * @return void
      */
-    abstract protected static function setRuntimeConfigValues() : void;
+    abstract protected static function setRuntimeConfigValues();
 
     /**
      * Set the environment without object instantiatin for simpler static usage
@@ -232,7 +232,7 @@ abstract class ManagerStructure
      *
      * @return void
      */
-    public static function setEnvironment(string $environment) : void
+    public static function setEnvironment(string $environment)
     {
         self::$environment = $environment;
     }
@@ -292,7 +292,7 @@ abstract class ManagerStructure
      *
      * @throws InvalidValueException if a value for a static key is not populated.
      */
-    protected static function validateConfigEnvRequirements() : void
+    protected static function validateConfigEnvRequirements()
     {
         foreach (self::ENV_REQUIRED_FIELDS as $fieldName) {
             $key = sprintf('%s.%s', self::getEnvironment(), $fieldName);
@@ -311,7 +311,7 @@ abstract class ManagerStructure
      *
      * @throws InvalidValueException if a value for a static key is not compatible with the SDK.
      */
-    protected static function validateInitialConfigData() : void
+    protected static function validateInitialConfigData()
     {
         foreach (self::STATIC_CONFIG_MAPPINGS as $key => $value) {
             if (static::doesValueExist($key) && static::getValue($key) !== $value) {

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -26,30 +26,30 @@ class Client implements IProtectClient
     /**
      * Define request types the HTTP client utilizes
      */
-    public const GET_REQUEST_TYPE    = 'GET';
-    public const POST_REQUEST_TYPE   = 'POST';
-    public const PUT_REQUEST_TYPE    = 'PUT';
-    public const DELETE_REQUEST_TYPE = 'DELETE';
+    const GET_REQUEST_TYPE    = 'GET';
+    const POST_REQUEST_TYPE   = 'POST';
+    const PUT_REQUEST_TYPE    = 'PUT';
+    const DELETE_REQUEST_TYPE = 'DELETE';
 
     /**
      * API prefix for NS8 Client routes
      */
-    public const ROUTE_PREFIX = '/api';
+    const ROUTE_PREFIX = '/api';
 
     /**
      * Default HTTP Request Timeout Value
      */
-    public const DEFAULT_TIMEOUT_VALUE = 30;
+    const DEFAULT_TIMEOUT_VALUE = 30;
 
     /**
      * Format for Authorization header value
      */
-    public const AUTH_STRING_HEADER_FORMAT = 'Bearer %s';
+    const AUTH_STRING_HEADER_FORMAT = 'Bearer %s';
 
     /**
      * A list of paths we should not log HTTP requests for
      */
-    public const EXCLUDED_LOG_PATHS = [ApiHandler::LOGGING_PATH];
+    const EXCLUDED_LOG_PATHS = [ApiHandler::LOGGING_PATH];
 
     /**
      * HTTP Library Client attribute
@@ -112,12 +112,12 @@ class Client implements IProtectClient
      * @param ?LoggingClient $loggingClient  Logging client used for recording request data
      */
     public function __construct(
-        ?string $authUsername = null,
-        ?string $accessToken = null,
+        $authUsername = null,
+        $accessToken = null,
         bool $setSessionData = true,
-        ?ZendClient $client = null,
-        ?ConfigManager $configManager = null,
-        ?LoggingClient $loggingClient = null
+        $client = null,
+        $configManager = null,
+        $loggingClient = null
     ) {
         $this->client        = $client ?? new ZendClient();
         $this->configManager = $configManager ?? new ConfigManager();
@@ -444,7 +444,7 @@ class Client implements IProtectClient
      *
      * @return mixed[]|null
      */
-    public function getSessionData() : ?array
+    public function getSessionData()
     {
         return $this->sessionData;
     }
@@ -468,7 +468,7 @@ class Client implements IProtectClient
      *
      * @return mixed[]|null
      */
-    public function getPlatformIdentifier() : ?string
+    public function getPlatformIdentifier()
     {
         return $this->platformIdentifier;
     }
@@ -492,7 +492,7 @@ class Client implements IProtectClient
      *
      * @return string|null
      */
-    public function getAuthUsername() : ?string
+    public function getAuthUsername()
     {
         return $this->authUsername;
     }
@@ -516,7 +516,7 @@ class Client implements IProtectClient
      *
      * @return string|null
      */
-    public function getAccessToken() : ?string
+    public function getAccessToken()
     {
         return $this->accessToken;
     }

--- a/src/Http/IProtectClient.php
+++ b/src/Http/IProtectClient.php
@@ -99,7 +99,7 @@ interface IProtectClient
      *
      * @return mixed[]|null
      */
-    public function getSessionData() : ?array;
+    public function getSessionData();
 
     /**
      * Set authusername used in post requests
@@ -115,7 +115,7 @@ interface IProtectClient
      *
      * @return string|null
      */
-    public function getAuthUsername() : ?string;
+    public function getAuthUsername();
 
     /**
      * Set access token used in requests with authentication
@@ -131,5 +131,5 @@ interface IProtectClient
      *
      * @return string|null
      */
-    public function getAccessToken() : ?string;
+    public function getAccessToken();
 }

--- a/src/Installer/Client.php
+++ b/src/Installer/Client.php
@@ -21,36 +21,36 @@ class Client extends BaseClient
     /**
      * Platform Installation endpoints
      */
-    public const INSTALL_ENDPOINT   = '/platform/install/%s';
-    public const REINSTALL_ENDPOINT = '/platform/reinstall/%s';
+    const INSTALL_ENDPOINT   = '/platform/install/%s';
+    const REINSTALL_ENDPOINT = '/platform/reinstall/%s';
 
     /**
      * Array keys required for NS8 Protect installation
      */
-    public const EMAIL_KEY        = 'email';
-    public const FIRST_NAME_KEY   = 'firstName';
-    public const LAST_NAME_KEY    = 'lastName';
-    public const PHONE_NUMBER_KEY = 'phone';
-    public const STORE_URL_KEY    = 'storeUrl';
+    const EMAIL_KEY        = 'email';
+    const FIRST_NAME_KEY   = 'firstName';
+    const LAST_NAME_KEY    = 'lastName';
+    const PHONE_NUMBER_KEY = 'phone';
+    const STORE_URL_KEY    = 'storeUrl';
 
     /**
      * Error messages to display for missing installation data
      */
-    public const EMAIL_MISSING_EXCEPTION_MESSAGE       =
+    const EMAIL_MISSING_EXCEPTION_MESSAGE       =
     'Array key "email" is missing: A valid email is required';
-    public const FIRST_NAME_MISSING_EXCEPTION_MESSAGE  =
+    const FIRST_NAME_MISSING_EXCEPTION_MESSAGE  =
     'Array key "firstName" is missing: A first name value is required';
-    public const LAST_NAME_MISSING_EXCEPTION_MESSAGE   =
+    const LAST_NAME_MISSING_EXCEPTION_MESSAGE   =
     'Array key "lastName" is missing: A last name value is required';
-    public const PHONE_NUMER_MISSING_EXCEPTION_MESSAGE =
+    const PHONE_NUMER_MISSING_EXCEPTION_MESSAGE =
     'Array key "phone" is missing: A phone number is required';
-    public const STORE_URL_MISSING_EXCEPTION_MESSAGE   =
+    const STORE_URL_MISSING_EXCEPTION_MESSAGE   =
     'Array key "storeUrl" is missing: A valid store URL (e.g. https://example.com) is required';
 
     /**
      * Mapping of required keys to their error message for missing installation information
      */
-    public const REQUIRED_ARRAY_KEY_VALIDATION_MAPPING = [
+    const REQUIRED_ARRAY_KEY_VALIDATION_MAPPING = [
         self::EMAIL_KEY => self::EMAIL_MISSING_EXCEPTION_MESSAGE,
         self::STORE_URL_KEY => self::STORE_URL_MISSING_EXCEPTION_MESSAGE,
     ];
@@ -110,7 +110,7 @@ class Client extends BaseClient
      *
      * @return void
      */
-    public static function setHttpClient(HttpClient $httpClient) : void
+    public static function setHttpClient(HttpClient $httpClient)
     {
         self::$httpClient = $httpClient;
     }
@@ -122,7 +122,7 @@ class Client extends BaseClient
      *
      * @return void
      */
-    protected static function validateInstallDataArray(array $installData) : void
+    protected static function validateInstallDataArray(array $installData)
     {
         foreach (self::REQUIRED_ARRAY_KEY_VALIDATION_MAPPING as $key => $message) {
             if (! array_key_exists($key, $installData)) {

--- a/src/Logging/Client.php
+++ b/src/Logging/Client.php
@@ -22,60 +22,60 @@ class Client extends ClientBase
     /**
      * Logging Channel for Monolog Usage
      */
-    public const LOGGER_CHANNEL_NAME = 'ns8';
+    const LOGGER_CHANNEL_NAME = 'ns8';
 
     /**
      * Debug Level Info For Logging
      */
-    public const LOG_LEVEL_DEBUG_NAME          = 'DEBUG';
-    public const LOG_LEVEL_DEBUG_INTEGER_VALUE = 100;
+    const LOG_LEVEL_DEBUG_NAME          = 'DEBUG';
+    const LOG_LEVEL_DEBUG_INTEGER_VALUE = 100;
 
     /**
      * Info Level Info For Logging
      */
-    public const LOG_LEVEL_INFO_NAME          = 'INFO';
-    public const LOG_LEVEL_INFO_INTEGER_VALUE = 200;
+    const LOG_LEVEL_INFO_NAME          = 'INFO';
+    const LOG_LEVEL_INFO_INTEGER_VALUE = 200;
 
     /**
      * Notice Level Info For Logging
      */
-    public const LOG_LEVEL_NOTICE_NAME          = 'NOTICE';
-    public const LOG_LEVEL_NOTICE_INTEGER_VALUE = 250;
+    const LOG_LEVEL_NOTICE_NAME          = 'NOTICE';
+    const LOG_LEVEL_NOTICE_INTEGER_VALUE = 250;
 
     /**
      * Warning Level Info For Logging
      */
-    public const LOG_LEVEL_WARNING_NAME          = 'WARNING';
-    public const LOG_LEVEL_WARNING_INTEGER_VALUE = 300;
+    const LOG_LEVEL_WARNING_NAME          = 'WARNING';
+    const LOG_LEVEL_WARNING_INTEGER_VALUE = 300;
 
     /**
      * Error Level Info For Logging
      */
-    public const LOG_LEVEL_ERROR_NAME          = 'ERROR';
-    public const LOG_LEVEL_ERROR_INTEGER_VALUE = 400;
+    const LOG_LEVEL_ERROR_NAME          = 'ERROR';
+    const LOG_LEVEL_ERROR_INTEGER_VALUE = 400;
 
     /**
      * Critical Level Info For Logging
      */
-    public const LOG_LEVEL_CRITICAL_NAME    = 'CRITICAL';
-    public const LOG_LEVEL_CRITICAL_INTEGER = 500;
+    const LOG_LEVEL_CRITICAL_NAME    = 'CRITICAL';
+    const LOG_LEVEL_CRITICAL_INTEGER = 500;
 
     /**
      * Alert Level Info For Logging
      */
-    public const LOG_LEVEL_ALERT_NAME    = 'ALERT';
-    public const LOG_LEVEL_ALERT_INTEGER = 550;
+    const LOG_LEVEL_ALERT_NAME    = 'ALERT';
+    const LOG_LEVEL_ALERT_INTEGER = 550;
 
     /**
      * Emergency Level Info For Logging
      */
-    public const LOG_LEVEL_EMERGENCY_NAME    = 'EMERGENCY';
-    public const LOG_LEVEL_EMERGENCY_INTEGER = 600;
+    const LOG_LEVEL_EMERGENCY_NAME    = 'EMERGENCY';
+    const LOG_LEVEL_EMERGENCY_INTEGER = 600;
 
     /**
      * Map log levels to their integer values
      */
-    public const LOG_LEVEL_MAPPING = [
+    const LOG_LEVEL_MAPPING = [
         self::LOG_LEVEL_DEBUG_NAME => self::LOG_LEVEL_DEBUG_INTEGER_VALUE,
         self::LOG_LEVEL_INFO_NAME => self::LOG_LEVEL_INFO_INTEGER_VALUE,
         self::LOG_LEVEL_NOTICE_NAME => self::LOG_LEVEL_NOTICE_INTEGER_VALUE,
@@ -105,7 +105,7 @@ class Client extends ClientBase
      * @param ?Logger        $logger        Logging object to be used by the client
      * @param ?ConfigManager $configManager Config manager used to fetch settings
      */
-    public function __construct(?Logger $logger = null, ?ConfigManager $configManager = null)
+    public function __construct($logger = null, $configManager = null)
     {
         $this->logger        = $logger ?? new Logger(self::LOGGER_CHANNEL_NAME);
         $this->configManager = $configManager ?? new ConfigManager();
@@ -121,7 +121,7 @@ class Client extends ClientBase
      *
      * @return void
      */
-    public function addHandler(AbstractMonologHandler $handler) : void
+    public function addHandler(AbstractMonologHandler $handler)
     {
         $this->logger->pushHandler($handler);
     }
@@ -135,7 +135,7 @@ class Client extends ClientBase
      *
      * @return void
      */
-    public function error(string $message, ?Throwable $event = null, ?array $data = null) : void
+    public function error(string $message, $event = null, $data = null)
     {
         $data = (array) $data;
         if (isset($event)) {
@@ -153,7 +153,7 @@ class Client extends ClientBase
      *
      * @return void
      */
-    public function debug(string $message, ?array $data = null) : void
+    public function debug(string $message, $data = null)
     {
         $this->logger->debug($message, (array) $data);
     }
@@ -166,7 +166,7 @@ class Client extends ClientBase
      *
      * @return void
      */
-    public function warn(string $message, ?array $data = null) : void
+    public function warn(string $message, $data = null)
     {
         $this->logger->warning($message, (array) $data);
     }
@@ -179,7 +179,7 @@ class Client extends ClientBase
      *
      * @return void
      */
-    public function info(string $message, ?array $data = null) : void
+    public function info(string $message, $data = null)
     {
         $this->logger->info($message, (array) $data);
     }

--- a/src/Logging/ClientBase.php
+++ b/src/Logging/ClientBase.php
@@ -20,7 +20,7 @@ abstract class ClientBase
      *
      * @return void
      */
-    abstract public function error(string $message, ?Throwable $event = null, ?array $data = null) : void;
+    abstract public function error(string $message, $event = null, $data = null);
 
     /**
      * Logs a message classified as a debugging line
@@ -30,7 +30,7 @@ abstract class ClientBase
      *
      * @return void
      */
-    abstract public function debug(string $message, ?array $data = null) : void;
+    abstract public function debug(string $message, $data = null);
 
     /**
      * Logs a message classified as a warning
@@ -40,7 +40,7 @@ abstract class ClientBase
      *
      * @return void
      */
-    abstract public function warn(string $message, ?array $data = null) : void;
+    abstract public function warn(string $message, $data = null);
 
     /**
      * Logs a message classified as information for developers/administrators
@@ -50,5 +50,5 @@ abstract class ClientBase
      *
      * @return void
      */
-    abstract public function info(string $message, ?array $data = null) : void;
+    abstract public function info(string $message, $data = null);
 }

--- a/src/Logging/Handlers/Api.php
+++ b/src/Logging/Handlers/Api.php
@@ -20,7 +20,7 @@ class Api extends AbstractProcessingHandler
     /**
      * API route we are sending log data to
      */
-    public const LOGGING_PATH = '/util/log-platform-error';
+    const LOGGING_PATH = '/util/log-platform-error';
     /**
      * Sets if the handler instance has been initialized
      *
@@ -57,7 +57,7 @@ class Api extends AbstractProcessingHandler
      * @param bool          $bubble        Determines if messages should bubble up to the next handler
      */
     public function __construct(
-        ?ConfigManager $configManager = null,
+        $configManager = null,
         int $level = Logger::DEBUG,
         bool $bubble = true
     ) {
@@ -97,7 +97,7 @@ class Api extends AbstractProcessingHandler
      *
      * @return void
      */
-    protected function write(array $record) : void
+    protected function write(array $record)
     {
         $this->client = $this->getHttpClient();
         try {
@@ -144,7 +144,7 @@ class Api extends AbstractProcessingHandler
      *
      * @return void
      */
-    private function initialize() : void
+    private function initialize()
     {
         $this->initialized = true;
     }

--- a/src/Merchants/BaseClient.php
+++ b/src/Merchants/BaseClient.php
@@ -14,7 +14,7 @@ abstract class BaseClient
     /**
      * The template endpoint.
      */
-    protected const CURRENT_MERCHANT_ENDPOINT = '/merchant/current';
+    const CURRENT_MERCHANT_ENDPOINT = '/merchant/current';
 
     /**
      * Get the current merchant.

--- a/src/Merchants/Client.php
+++ b/src/Merchants/Client.php
@@ -48,7 +48,7 @@ class Client extends BaseClient
      *
      * @return void
      */
-    public static function setHttpClient(HttpClient $httpClient) : void
+    public static function setHttpClient(HttpClient $httpClient)
     {
         self::$httpClient = $httpClient;
     }

--- a/src/Order/Client.php
+++ b/src/Order/Client.php
@@ -19,9 +19,9 @@ class Client extends BaseClient
     /**
      * Order status values for NS8 Protect Orders
      */
-    public const APPROVED_STATE        = 'APPROVED';
-    public const CANCELLED_STATE       = 'CANCELLED';
-    public const MERCHANT_REVIEW_STATE = 'MERCHANT_REVIEW';
+    const APPROVED_STATE        = 'APPROVED';
+    const CANCELLED_STATE       = 'CANCELLED';
+    const MERCHANT_REVIEW_STATE = 'MERCHANT_REVIEW';
 
     /**
      * Get the current merchant.

--- a/src/Queue/BaseClient.php
+++ b/src/Queue/BaseClient.php
@@ -18,7 +18,7 @@ abstract class BaseClient
      *
      * @return void
      */
-    abstract public static function initialize(?ZendClient $httpClient = null) : void;
+    abstract public static function initialize($httpClient = null);
 
     /**
      * Returns the URL being used for queue iteration during runtime
@@ -33,7 +33,7 @@ abstract class BaseClient
      *
      * @return mixed[]|null Message array for data
      */
-    abstract public static function getMessages() : ?array;
+    abstract public static function getMessages();
 
     /**
      * Process results to check if any errors exist
@@ -43,7 +43,7 @@ abstract class BaseClient
      *
      * @return void
      */
-    abstract protected static function processResultErrors(array $responseArray, string $responseString) : void;
+    abstract protected static function processResultErrors(array $responseArray, string $responseString);
 
     /**
      * Returns a formatted array of messages from the queue given the result output
@@ -52,5 +52,5 @@ abstract class BaseClient
      *
      * @return mixed[]|null
      */
-    abstract protected static function parseResponseMessages(array $responseArray) : ?array;
+    abstract protected static function parseResponseMessages(array $responseArray);
 }

--- a/src/Queue/Client.php
+++ b/src/Queue/Client.php
@@ -43,39 +43,39 @@ class Client extends BaseClient
     /**
      * SQS Request Constants
      */
-    public const DEFAULT_SQS_REQUEST_TYPE = 'GET';
+    const DEFAULT_SQS_REQUEST_TYPE = 'GET';
 
     /**
      * URLs to manage SQS information through Protect
      */
-    public const GET_QUEUE_URL            = '/polling/GetQueueUrl';
-    public const DELETE_QUEUE_MESSAGE_URL = '/polling/DeleteQueueMessage';
+    const GET_QUEUE_URL            = '/polling/GetQueueUrl';
+    const DELETE_QUEUE_MESSAGE_URL = '/polling/DeleteQueueMessage';
 
     /**
      * Error keys used when receiving errors from SQS
      */
-    public const ERROR_KEY         = 'Error';
-    public const ERROR_CODE_KEY    = 'Code';
-    public const ERROR_MESSAGE_KEY = 'Message';
+    const ERROR_KEY         = 'Error';
+    const ERROR_CODE_KEY    = 'Code';
+    const ERROR_MESSAGE_KEY = 'Message';
 
     /**
      * Message keys used when parsing messages from SQS
      */
-    public const RECEIVE_MESSAGE_RESPONSE_KEY = 'ReceiveMessageResponse';
-    public const RECEIVE_MESSAGE_RESULT_KEY   = 'ReceiveMessageResult';
-    public const RECEIVE_MESSAGE_SET_KEY      = 'messages';
+    const RECEIVE_MESSAGE_RESPONSE_KEY = 'ReceiveMessageResponse';
+    const RECEIVE_MESSAGE_RESULT_KEY   = 'ReceiveMessageResult';
+    const RECEIVE_MESSAGE_SET_KEY      = 'messages';
 
     /**
      * Available message actions that can be present in a message
      */
-    public const MESSAGE_ACTION_UPDATE_EQ8_SCORE          = 'UPDATE_EQ8_SCORE_EVENT';
-    public const MESSAGE_ACTION_UPDATE_ORDER_RISK_EVENT   = 'UPDATE_ORDER_RISK_EVENT';
-    public const MESSAGE_ACTION_UPDATE_ORDER_STATUS_EVENT = 'UPDATE_ORDER_STATUS_EVENT';
+    const MESSAGE_ACTION_UPDATE_EQ8_SCORE          = 'UPDATE_EQ8_SCORE_EVENT';
+    const MESSAGE_ACTION_UPDATE_ORDER_RISK_EVENT   = 'UPDATE_ORDER_RISK_EVENT';
+    const MESSAGE_ACTION_UPDATE_ORDER_STATUS_EVENT = 'UPDATE_ORDER_STATUS_EVENT';
 
     /**
      * Static headers that we are required to send in SQS requests
      */
-    public const REQUIRED_HEADERS = ['Accept' => 'application/json'];
+    const REQUIRED_HEADERS = ['Accept' => 'application/json'];
 
     /**
      * Initializes the class to ensure attributes are set up correctly.
@@ -85,7 +85,7 @@ class Client extends BaseClient
      *
      * @return void
      */
-    public static function initialize(?ZendClient $httpClient = null, ?string $queueUrl = null) : void
+    public static function initialize($httpClient = null, $queueUrl = null)
     {
         self::$url        = $queueUrl;
         self::$httpClient = $httpClient ?? new ZendClient();
@@ -114,7 +114,7 @@ class Client extends BaseClient
      *
      * @return mixed[]|null Message array for data
      */
-    public static function getMessages() : ?array
+    public static function getMessages()
     {
         self::$httpClient->resetParameters();
         self::$httpClient->setHeaders(self::REQUIRED_HEADERS);
@@ -162,7 +162,7 @@ class Client extends BaseClient
      *
      * @return void
      */
-    public static function setNs8HttpClient(NS8HttpClient $ns8HttpClient) : void
+    public static function setNs8HttpClient(NS8HttpClient $ns8HttpClient)
     {
         self::$ns8HttpClient = $ns8HttpClient;
     }
@@ -178,7 +178,7 @@ class Client extends BaseClient
      * @throws DecodingException
      * @throws ResponseException
      */
-    protected static function processResultErrors(array $response, string $responseString) : void
+    protected static function processResultErrors(array $response, string $responseString)
     {
         if (empty($response)) {
             throw new DecodingException(
@@ -201,7 +201,7 @@ class Client extends BaseClient
      *
      * @return mixed[]
      */
-    protected static function parseResponseMessages(array $response) : ?array
+    protected static function parseResponseMessages(array $response)
     {
         $messages =
         $response[self::RECEIVE_MESSAGE_RESPONSE_KEY][self::RECEIVE_MESSAGE_RESULT_KEY][self::RECEIVE_MESSAGE_SET_KEY];

--- a/src/Security/BaseClient.php
+++ b/src/Security/BaseClient.php
@@ -33,7 +33,7 @@ abstract class BaseClient
      *
      * @return void
      */
-    abstract public static function setNs8AccessToken(string $accessToken) : void;
+    abstract public static function setNs8AccessToken(string $accessToken);
 
     /**
      * Validate NS8 Auth User
@@ -42,7 +42,7 @@ abstract class BaseClient
      *
      * @return bool Returns true if NS8 Auth User is valid, false otherwise
      */
-    abstract public static function validateAuthUser(?string $authUser) : bool;
+    abstract public static function validateAuthUser($authUser) : bool;
 
     /**
      * Returns the NS8 Auth User to be used when sending requests to NS8.
@@ -59,5 +59,5 @@ abstract class BaseClient
      *
      * @return void
      */
-    abstract public static function setAuthUser(string $authUser) : void;
+    abstract public static function setAuthUser(string $authUser);
 }

--- a/src/Security/Client.php
+++ b/src/Security/Client.php
@@ -41,7 +41,7 @@ class Client extends BaseClient
       *
       * @return void
       */
-    public static function setConfigManager(ConfigManager $configManager) : void
+    public static function setConfigManager(ConfigManager $configManager)
     {
         self::$configManager = $configManager;
     }
@@ -76,7 +76,7 @@ class Client extends BaseClient
      *
      * @return void
      */
-    public static function setNs8AccessToken(string $accessToken) : void
+    public static function setNs8AccessToken(string $accessToken)
     {
         $configKey = sprintf('%s.authorization.access_token', ConfigManager::getEnvironment());
         self::getConfigManager()->setValue($configKey, $accessToken);
@@ -89,7 +89,7 @@ class Client extends BaseClient
      *
      * @return bool Returns true if NS8 Auth User is valid, false otherwise
      */
-    public static function validateAuthUser(?string $authUser) : bool
+    public static function validateAuthUser($authUser) : bool
     {
         return ! self::getConfigManager()->getEnvValue('authorization.required') || ! empty($authUser);
     }
@@ -112,7 +112,7 @@ class Client extends BaseClient
      *
      * @return void
      */
-    public static function setAuthUser(string $authUser) : void
+    public static function setAuthUser(string $authUser)
     {
         $configKey = sprintf('%s.authorization.auth_user', ConfigManager::getEnvironment());
         self::getConfigManager()->setValue($configKey, $authUser);

--- a/src/Templates/BaseClient.php
+++ b/src/Templates/BaseClient.php
@@ -14,12 +14,12 @@ abstract class BaseClient
     /**
      * The template endpoint.
      */
-    protected const TEMPLATE_ENDPOINT = '/merchant/template';
+    const TEMPLATE_ENDPOINT = '/merchant/template';
 
     /**
      * The list of valid views that can be provided by the Template Service.
      */
-    protected const VALID_VIEWS = [
+    const VALID_VIEWS = [
         'orders-reject',
         'orders-reject-confirm',
         'orders-validate',
@@ -46,6 +46,6 @@ abstract class BaseClient
         string $token,
         string $verificationId,
         string $returnUri,
-        ?array $postParams = null
+        $postParams = null
     ) : stdClass;
 }

--- a/src/Templates/Client.php
+++ b/src/Templates/Client.php
@@ -44,7 +44,7 @@ class Client extends BaseClient
         string $token,
         string $verificationId,
         string $returnUri,
-        ?array $postParams = null
+        $postParams = null
     ) : stdClass {
         if (! in_array($view, self::VALID_VIEWS)) {
             throw new RuntimeException(sprintf('Invalid view "%s" specified', $view));
@@ -84,7 +84,7 @@ class Client extends BaseClient
      *
      * @return void
      */
-    public static function setHttpClient(HttpClient $httpClient) : void
+    public static function setHttpClient(HttpClient $httpClient)
     {
         self::$httpClient = $httpClient;
     }

--- a/src/Uninstaller/Client.php
+++ b/src/Uninstaller/Client.php
@@ -51,7 +51,7 @@ class Client extends BaseClient
      *
      * @return void
      */
-    public static function setHttpClient(HttpClient $httpClient) : void
+    public static function setHttpClient(HttpClient $httpClient)
     {
         self::$httpClient = $httpClient;
     }


### PR DESCRIPTION
Changes for PHP 7.0

# Story Reference

[ch42795](https://app.clubhouse.io/ns8/story/42795/update-protect-sdk-php-to-support-php-5)

## Summary

WordPress still has fairly large amounts of users for older PHP versions. I've made a number of changes that support PHP 7.0. I've also added new rule exclusions to CodeSniffer to account for these. These changes should be forward-compatible.

There were some unfortunate things I had to remove, like:
* constants with visibility
* void return type
* nullable types (hints were removed completely)

Hopefully this isn't too bad! At this moment we're holding off on any PHP 5 support.

## Author Checklist

I have added/updated:

- [ ] Tests
- [x] Documentation (linting rules)
- [ ] Release notes (title of this PR)

## Version Bump

- [x] Patch (bug fix - backwards compatible)
- [ ] Minor (new functionality - backwards compatible)
- [ ] Major (significant change - not backwards compatible)
